### PR TITLE
Hacky usage of location.hostname

### DIFF
--- a/net_drivers/webrtc/js/api.js
+++ b/net_drivers/webrtc/js/api.js
@@ -99,8 +99,8 @@ mergeInto(LibraryManager.library, {
 
     __js_game_client_start: function(hostPtr, port) {
         return Asyncify.handleSleep(function (wakeUp) {
-			// Ignore the ip and just connect to the web host address
-			console.log("Connecting to " + location.hostname);
+            // Ignore the ip and just connect to the web host address
+            console.log("Connecting to " + location.hostname);
             this.gameClient.connect(location.hostname, port).then(() => {
                 wakeUp(0)
             }).catch(_ => {

--- a/net_drivers/webrtc/js/api.js
+++ b/net_drivers/webrtc/js/api.js
@@ -99,7 +99,9 @@ mergeInto(LibraryManager.library, {
 
     __js_game_client_start: function(hostPtr, port) {
         return Asyncify.handleSleep(function (wakeUp) {
-            this.gameClient.connect(UTF8ToString(hostPtr), port).then(() => {
+			// Ignore the ip and just connect to the web host address
+			console.log("Connecting to " + location.hostname);
+            this.gameClient.connect(location.hostname, port).then(() => {
                 wakeUp(0)
             }).catch(_ => {
                 wakeUp(-1)


### PR DESCRIPTION
In the WebRTC driver, just make the client connect straight to location.hostname instead of whatever IP the client asked for :)