### PR TITLE
Fix undefined behavior left shift

### DIFF
--- a/nbnet.h
+++ b/nbnet.h
@@ -118,7 +118,7 @@ typedef uint32_t Word;
 #define WORD_BITS (WORD_BYTES * 8)
 #define BITS_REQUIRED(min, max) (min == max) ? 0 : GetRequiredNumberOfBitsFor(max - min)
 
-#define B_MASK(n) (1 << (n))
+#define B_MASK(n) (1u << (n))
 #define B_SET(mask, n) (mask |= B_MASK(n))
 #define B_UNSET(mask, n) (mask &= ~B_MASK(n))
 #define B_IS_SET(mask, n) ((B_MASK(n) & mask) == B_MASK(n))


### PR DESCRIPTION
I was trying out nbnet with Zig which has undefined behavior sanitizers on by default and caught this:
```
for (unsigned int i = 0; i < 32; i++)
    {
        if (B_IS_UNSET(packet->header.ack_bits, i))
            continue;
```
in `Connection_DecodePacketHeader`
pushes a 1 into the sign bit of 1 which is ub