### PR TITLE
Fix for MSVC C++ Compilation Issue with Compound Literals

### DIFF
--- a/nbnet.h
+++ b/nbnet.h
@@ -4494,10 +4494,10 @@ static void Endpoint_Init(NBN_Endpoint *endpoint, NBN_Config config, bool is_ser
         endpoint->message_serializers[i] = NULL;
     }
 
-    NBN_RPC temp_rpc = {.id = UINT_MAX};
+    NBN_RPC rpc = {.id = UINT_MAX};
     for (int i = 0; i < NBN_RPC_MAX; i++)
     {
-        endpoint->rpcs[i] = temp_rpc;
+        endpoint->rpcs[i] = rpc;
     }
 
     NBN_EventQueue_Init(&endpoint->event_queue);

--- a/net_drivers/udp.h
+++ b/net_drivers/udp.h
@@ -685,24 +685,24 @@ static int NBN_UDP_CliSendPacket(NBN_Packet *packet)
 void NBN_UDP_Register(void)
 {
     NBN_DriverImplementation driver_impl = {
-            // Client implementation
-            NBN_UDP_CliStart,
-            NBN_UDP_CliStop,
-            NBN_UDP_CliRecvPackets,
-            NBN_UDP_CliSendPacket,
+		// Client implementation
+		NBN_UDP_CliStart,
+		NBN_UDP_CliStop,
+		NBN_UDP_CliRecvPackets,
+		NBN_UDP_CliSendPacket,
 
-            // Server implementation
-            NBN_UDP_ServStart,
-            NBN_UDP_ServStop,
-            NBN_UDP_ServRecvPackets,
-            NBN_UDP_ServSendPacketTo,
-            NBN_UDP_ServRemoveClientConnection
+		// Server implementation
+		NBN_UDP_ServStart,
+		NBN_UDP_ServStop,
+		NBN_UDP_ServRecvPackets,
+		NBN_UDP_ServSendPacketTo,
+		NBN_UDP_ServRemoveClientConnection
     };
 
     NBN_Driver_Register(
-            NBN_UDP_DRIVER_ID,
-            NBN_UDP_DRIVER_NAME,
-            driver_impl
+		NBN_UDP_DRIVER_ID,
+		NBN_UDP_DRIVER_NAME,
+		driver_impl
     );
 }
 

--- a/net_drivers/udp.h
+++ b/net_drivers/udp.h
@@ -693,8 +693,8 @@ void NBN_UDP_Register(void)
 
         // Server implementation
         NBN_UDP_ServStart,
-	    NBN_UDP_ServStop,
-	    NBN_UDP_ServRecvPackets,
+        NBN_UDP_ServStop,
+        NBN_UDP_ServRecvPackets,
         NBN_UDP_ServSendPacketTo,
         NBN_UDP_ServRemoveClientConnection
     };

--- a/net_drivers/udp.h
+++ b/net_drivers/udp.h
@@ -684,10 +684,7 @@ static int NBN_UDP_CliSendPacket(NBN_Packet *packet)
 
 void NBN_UDP_Register(void)
 {
-    NBN_Driver_Register(
-        NBN_UDP_DRIVER_ID,
-        NBN_UDP_DRIVER_NAME,
-        (NBN_DriverImplementation){
+    NBN_DriverImplementation driver_impl = {
             // Client implementation
             NBN_UDP_CliStart,
             NBN_UDP_CliStop,
@@ -700,7 +697,12 @@ void NBN_UDP_Register(void)
             NBN_UDP_ServRecvPackets,
             NBN_UDP_ServSendPacketTo,
             NBN_UDP_ServRemoveClientConnection
-        }
+    };
+
+    NBN_Driver_Register(
+            NBN_UDP_DRIVER_ID,
+            NBN_UDP_DRIVER_NAME,
+            driver_impl
     );
 }
 

--- a/net_drivers/udp.h
+++ b/net_drivers/udp.h
@@ -685,24 +685,24 @@ static int NBN_UDP_CliSendPacket(NBN_Packet *packet)
 void NBN_UDP_Register(void)
 {
     NBN_DriverImplementation driver_impl = {
-		// Client implementation
-		NBN_UDP_CliStart,
-		NBN_UDP_CliStop,
-		NBN_UDP_CliRecvPackets,
-		NBN_UDP_CliSendPacket,
+        // Client implementation
+        NBN_UDP_CliStart,
+        NBN_UDP_CliStop,
+        NBN_UDP_CliRecvPackets,
+        NBN_UDP_CliSendPacket,
 
-		// Server implementation
-		NBN_UDP_ServStart,
-		NBN_UDP_ServStop,
-		NBN_UDP_ServRecvPackets,
-		NBN_UDP_ServSendPacketTo,
-		NBN_UDP_ServRemoveClientConnection
+        // Server implementation
+        NBN_UDP_ServStart,
+	    NBN_UDP_ServStop,
+	    NBN_UDP_ServRecvPackets,
+        NBN_UDP_ServSendPacketTo,
+        NBN_UDP_ServRemoveClientConnection
     };
 
     NBN_Driver_Register(
-		NBN_UDP_DRIVER_ID,
-		NBN_UDP_DRIVER_NAME,
-		driver_impl
+        NBN_UDP_DRIVER_ID,
+        NBN_UDP_DRIVER_NAME,
+        driver_impl
     );
 }
 

--- a/net_drivers/webrtc.h
+++ b/net_drivers/webrtc.h
@@ -447,10 +447,7 @@ static int NBN_WebRTC_CliSendPacket(NBN_Packet *packet)
 
 void NBN_WebRTC_Register(void)
 {
-    NBN_Driver_Register(
-        NBN_WEBRTC_DRIVER_ID,
-        NBN_WEBRTC_DRIVER_NAME,
-        (NBN_DriverImplementation){
+    NBN_DriverImplementation driver_impl = {
             // Client implementation
             NBN_WebRTC_CliStart,
             NBN_WebRTC_CliStop,
@@ -463,7 +460,12 @@ void NBN_WebRTC_Register(void)
             NBN_WebRTC_ServRecvPackets,
             NBN_WebRTC_ServSendPacketTo,
             NBN_WebRTC_ServRemoveClientConnection
-        }
+    };
+
+    NBN_Driver_Register(
+        NBN_WEBRTC_DRIVER_ID,
+        NBN_WEBRTC_DRIVER_NAME,
+        driver_impl
     );
 }
 

--- a/net_drivers/webrtc.h
+++ b/net_drivers/webrtc.h
@@ -448,18 +448,18 @@ static int NBN_WebRTC_CliSendPacket(NBN_Packet *packet)
 void NBN_WebRTC_Register(void)
 {
     NBN_DriverImplementation driver_impl = {
-            // Client implementation
-            NBN_WebRTC_CliStart,
-            NBN_WebRTC_CliStop,
-            NBN_WebRTC_CliRecvPackets,
-            NBN_WebRTC_CliSendPacket,
+		// Client implementation
+		NBN_WebRTC_CliStart,
+		NBN_WebRTC_CliStop,
+		NBN_WebRTC_CliRecvPackets,
+		NBN_WebRTC_CliSendPacket,
 
-            // Server implementation
-            NBN_WebRTC_ServStart,
-            NBN_WebRTC_ServStop,
-            NBN_WebRTC_ServRecvPackets,
-            NBN_WebRTC_ServSendPacketTo,
-            NBN_WebRTC_ServRemoveClientConnection
+		// Server implementation
+		NBN_WebRTC_ServStart,
+		NBN_WebRTC_ServStop,
+		NBN_WebRTC_ServRecvPackets,
+		NBN_WebRTC_ServSendPacketTo,
+		NBN_WebRTC_ServRemoveClientConnection
     };
 
     NBN_Driver_Register(

--- a/net_drivers/webrtc.h
+++ b/net_drivers/webrtc.h
@@ -448,18 +448,18 @@ static int NBN_WebRTC_CliSendPacket(NBN_Packet *packet)
 void NBN_WebRTC_Register(void)
 {
     NBN_DriverImplementation driver_impl = {
-		// Client implementation
-		NBN_WebRTC_CliStart,
-		NBN_WebRTC_CliStop,
-		NBN_WebRTC_CliRecvPackets,
-		NBN_WebRTC_CliSendPacket,
+        // Client implementation
+        NBN_WebRTC_CliStart,
+        NBN_WebRTC_CliStop,
+        NBN_WebRTC_CliRecvPackets,
+        NBN_WebRTC_CliSendPacket,
 
-		// Server implementation
-		NBN_WebRTC_ServStart,
-		NBN_WebRTC_ServStop,
-		NBN_WebRTC_ServRecvPackets,
-		NBN_WebRTC_ServSendPacketTo,
-		NBN_WebRTC_ServRemoveClientConnection
+        // Server implementation
+        NBN_WebRTC_ServStart,
+        NBN_WebRTC_ServStop,
+        NBN_WebRTC_ServRecvPackets,
+        NBN_WebRTC_ServSendPacketTo,
+        NBN_WebRTC_ServRemoveClientConnection
     };
 
     NBN_Driver_Register(

--- a/net_drivers/webrtc_c.h
+++ b/net_drivers/webrtc_c.h
@@ -665,18 +665,19 @@ static int NBN_WebRTC_C_ServSendPacketTo(NBN_Packet *packet, NBN_Connection *con
 void NBN_WebRTC_C_Register(void)
 {
     NBN_DriverImplementation driver_impl {
-            // Client implementation
-            NULL,
-            NULL,
-            NULL,
-            NULL,
+        // Client implementation
+        NULL,
+        NULL,
+        NULL,
+        NULL,
 
-            // Server implementation
-            NBN_WebRTC_C_ServStart,
-            NBN_WebRTC_C_ServStop,
-            NBN_WebRTC_C_ServRecvPackets,
-            NBN_WebRTC_C_ServSendPacketTo,
-            NBN_WebRTC_C_ServRemoveClientConnection};
+        // Server implementation
+        NBN_WebRTC_C_ServStart,
+        NBN_WebRTC_C_ServStop,
+        NBN_WebRTC_C_ServRecvPackets,
+        NBN_WebRTC_C_ServSendPacketTo,
+        NBN_WebRTC_C_ServRemoveClientConnection
+    };
 
     NBN_Driver_Register(
         NBN_WEBRTC_C_DRIVER_ID,

--- a/net_drivers/webrtc_c.h
+++ b/net_drivers/webrtc_c.h
@@ -664,22 +664,25 @@ static int NBN_WebRTC_C_ServSendPacketTo(NBN_Packet *packet, NBN_Connection *con
 
 void NBN_WebRTC_C_Register(void)
 {
-    NBN_Driver_Register(
-        NBN_WEBRTC_C_DRIVER_ID,
-        NBN_WEBRTC_C_DRIVER_NAME,
-        (NBN_DriverImplementation){
+    NBN_DriverImplementation driver_impl {
             // Client implementation
             NULL,
             NULL,
             NULL,
             NULL,
-            
+
             // Server implementation
             NBN_WebRTC_C_ServStart,
             NBN_WebRTC_C_ServStop,
             NBN_WebRTC_C_ServRecvPackets,
             NBN_WebRTC_C_ServSendPacketTo,
-            NBN_WebRTC_C_ServRemoveClientConnection});
+            NBN_WebRTC_C_ServRemoveClientConnection};
+
+    NBN_Driver_Register(
+        NBN_WEBRTC_C_DRIVER_ID,
+        NBN_WEBRTC_C_DRIVER_NAME,
+        driver_impl
+    );
 }
 
 #endif // NBNET_IMPL


### PR DESCRIPTION
This pull request addresses compilation issues encountered when using MSVC as a C++ compiler with the library. While I understand that this library is primarily designed to be a C99 library, there's an example provided that integrates with raylib. Given that raylib can be compiled in C++, it would be beneficial for this library to be compatible with C++ compilation as well.

The original code utilized compound literals, a feature introduced in C99. While this is valid in C99, MSVC does not support this feature when compiling in C++ mode, leading to two errors:

- "C4576: a type in parentheses followed by an initializer list is a non-standard explicit type conversion syntax."
- "C7556: cannot mix designated initializers with non-designated initializers."

To address these issues, I've introduced a temporary variable to initialize the struct before passing it to the function. This change ensures compatibility with MSVC and allows for successful compilation in C++.

I believe this adjustment will enhance the library's versatility, especially for those who might be using MSVC as their C++ compiler or integrating with C++ projects. Feedback and suggestions are welcome!

