### PR TITLE
Duplicate host string with NBN_Allocator in ResolveIpAddress

### DIFF
--- a/net_drivers/udp.h
+++ b/net_drivers/udp.h
@@ -398,7 +398,7 @@ static int BindSocket(uint16_t port)
 static int ResolveIpAddress(const char *host, uint16_t port, NBN_IPAddress *address)
 {
     size_t host_len = strlen(host);
-    char *dup_host = NBN_Allocator(host_len + 1);
+    char *dup_host = (char*)NBN_Allocator(host_len + 1);
     memcpy(dup_host, host, host_len + 1);
     uint8_t arr[4];
 

--- a/net_drivers/udp.h
+++ b/net_drivers/udp.h
@@ -397,7 +397,9 @@ static int BindSocket(uint16_t port)
 
 static int ResolveIpAddress(const char *host, uint16_t port, NBN_IPAddress *address)
 {
-    char *dup_host = strdup(host);
+    size_t host_len = strlen(host);
+    char *dup_host = NBN_Allocator(host_len + 1);
+    memcpy(dup_host, host, host_len + 1);
     uint8_t arr[4];
 
     for (int i = 0; i < 4; i++)


### PR DESCRIPTION
Currently the host string in `ResolveIpAddress` is duplicated with `strdup` and deallocated with `NBN_Deallocator`. Given that `NBN_Deallocator` can be changed from the default `free` - the allocation and deallocation of this struct could use two different allocators.