### PR TITLE
fix: corrected `type-limits` and `missing-field-initializers` warnings

### DIFF
--- a/nbnet.h
+++ b/nbnet.h
@@ -1731,10 +1731,10 @@ struct NBN_Driver
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 static NBN_Driver nbn_drivers[NBN_MAX_DRIVERS] = {
-    {-1, NULL},
-    {-1, NULL},
-    {-1, NULL},
-    {-1, NULL}
+    { .id = -1 },
+    { .id = -1 },
+    { .id = -1 },
+    { .id = -1 }
 };
 #pragma clang diagnostic pop
 
@@ -2415,7 +2415,7 @@ int NBN_ReadStream_SerializeBool(NBN_ReadStream *read_stream, bool *value)
     if (NBN_BitReader_Read(&read_stream->bit_reader, &v, 1) < 0)
         return NBN_ERROR;
 
-    if (v < 0 || v > 1)
+    if (v > 1)
         return NBN_ERROR;
 
     *value = v;
@@ -3106,7 +3106,7 @@ void NBN_ClientAcceptedMessage_Destroy(NBN_ClientAcceptedMessage *msg)
 
 int NBN_ClientAcceptedMessage_Serialize(NBN_ClientAcceptedMessage *msg, NBN_Stream *stream)
 {
-    NBN_SerializeUInt(stream, msg->length, 0, NBN_SERVER_DATA_MAX_SIZE);
+    NBN_SerializeUInt(stream, msg->length, 1, NBN_SERVER_DATA_MAX_SIZE);
     NBN_SerializeBytes(stream, msg->data, msg->length);
 
     return 0;
@@ -3128,7 +3128,7 @@ void NBN_ByteArrayMessage_Destroy(NBN_ByteArrayMessage *msg)
 
 int NBN_ByteArrayMessage_Serialize(NBN_ByteArrayMessage *msg, NBN_Stream *stream)
 {
-    NBN_SerializeUInt(stream, msg->length, 0, NBN_BYTE_ARRAY_MAX_SIZE);
+    NBN_SerializeUInt(stream, msg->length, 1, NBN_BYTE_ARRAY_MAX_SIZE);
     NBN_SerializeBytes(stream, msg->bytes, msg->length);
 
     return 0;
@@ -3218,7 +3218,7 @@ void NBN_ConnectionRequestMessage_Destroy(NBN_ConnectionRequestMessage *msg)
 
 int NBN_ConnectionRequestMessage_Serialize(NBN_ConnectionRequestMessage *msg, NBN_Stream *stream)
 {
-    NBN_SerializeUInt(stream, msg->length, 0, NBN_CONNECTION_DATA_MAX_SIZE);
+    NBN_SerializeUInt(stream, msg->length, 1, NBN_CONNECTION_DATA_MAX_SIZE);
     NBN_SerializeBytes(stream, msg->data, msg->length);
 
     return 0;
@@ -3240,8 +3240,8 @@ void NBN_RPC_Message_Destroy(NBN_RPC_Message *msg)
 
 int NBN_RPC_Message_Serialize(NBN_RPC_Message *msg, NBN_Stream *stream)
 {
-    NBN_SerializeUInt(stream, msg->id, 0, NBN_RPC_MAX);
-    NBN_SerializeUInt(stream, msg->param_count, 0, NBN_RPC_MAX_PARAM_COUNT);
+    NBN_SerializeUInt(stream, msg->id, 1, NBN_RPC_MAX);
+    NBN_SerializeUInt(stream, msg->param_count, 1, NBN_RPC_MAX_PARAM_COUNT);
 
     for (unsigned int i = 0; i < msg->param_count; i++)
     {
@@ -3987,7 +3987,7 @@ static NBN_RPC_Message *Connection_BuildRPC(NBN_Connection *connection, NBN_RPC 
 
 static void Connection_HandleReceivedRPC(NBN_ConnectionHandle connection, NBN_Endpoint *endpoint, NBN_RPC_Message *msg)
 {
-    if (msg->id < 0 || msg->id > NBN_RPC_MAX - 1)
+    if (msg->id > NBN_RPC_MAX - 1)
     {
         NBN_LogError("Received an invalid RPC");
 
@@ -4753,7 +4753,7 @@ static NBN_Connection *Endpoint_CreateConnection(NBN_Endpoint *endpoint, uint32_
 
 static int Endpoint_RegisterRPC(NBN_Endpoint *endpoint, unsigned int id, NBN_RPC_Signature signature, NBN_RPC_Func func)
 {
-    if (id < 0 || id >= NBN_RPC_MAX)
+    if (id >= NBN_RPC_MAX)
     {
         NBN_LogError("Failed to register RPC, invalid ID");
 
@@ -5365,7 +5365,7 @@ int NBN_GameClient_CallRPC(unsigned int id, ...)
 {
     NBN_RPC rpc = nbn_game_client.endpoint.rpcs[id];
 
-    if (rpc.id < 0 || rpc.id != id)
+    if (rpc.id != id)
     {
         NBN_LogError("Cannot call invalid RPC (ID: %d)", id);
 
@@ -5992,7 +5992,7 @@ int NBN_GameServer_CallRPC(unsigned int id, NBN_ConnectionHandle connection_hand
 
     NBN_RPC rpc = nbn_game_server.endpoint.rpcs[id];
 
-    if (rpc.id < 0 || rpc.id != id)
+    if (rpc.id != id)
     {
         NBN_LogError("Cannot call invalid RPC (ID: %d)", id);
 

--- a/nbnet.h
+++ b/nbnet.h
@@ -1728,15 +1728,12 @@ struct NBN_Driver
     NBN_DriverImplementation impl;
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
 static NBN_Driver nbn_drivers[NBN_MAX_DRIVERS] = {
     { .id = -1 },
     { .id = -1 },
     { .id = -1 },
     { .id = -1 }
 };
-#pragma clang diagnostic pop
 
 static unsigned int nbn_driver_count = 0;
 
@@ -2751,7 +2748,7 @@ static void AES_CBC_decrypt_buffer(struct AES_ctx*, uint8_t*, uint32_t);
 
 void poly1305_auth(uint8_t out[POLY1305_TAGLEN], const uint8_t *m, size_t inlen,
                    const uint8_t key[POLY1305_KEYLEN])
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && defined(__clang__)
     __attribute__((__bounded__(__minbytes__, 1, POLY1305_TAGLEN)))
     __attribute__((__bounded__(__buffer__, 2, 3)))
     __attribute__((__bounded__(__minbytes__, 4, POLY1305_KEYLEN)))


### PR DESCRIPTION
First of all, thanks for this amazing library; I've discovered it a couple of days ago and I've been enjoying it so much, so I wanted to contribute some fixes for a couple of minor problems I've encountered along the way :D

When compiling a translation unit which includes the `nbnet.h` header as well as its implementation (`#define NBNET_IMPL`) with all warnings (`-Wall`) and extra warnings (`-Wextra`), it spits some warnings, most of them being of the `type-limits` kind [1], and some more being of the `missing-field-initializers` kind [2].

[1] Most of the warnings appear in places where comparisons involving `unsigned` data types (e.g. `unsigned int`) and the number 0. For instance (`@@ -3987,7 +3987,7 @@`):
```c
unsigned int id;
if (id < 0 || id >= NBN_RPC_MAX)
```
In this case, checking if the value stores within an `unsigned int` is less than 0 will always return false (0), as the `unsigned` keyword specifies that the corresponding variable can only represent non-negative values, so when storing a negative value inside it it will result in actually storing a 0. As a result of this, all these comparisons are unnecessary.

[2] In the diff `@@ -1731,10 +1731,10 @@`, it's being created an array of `NBN_Driver` with a max capacity of `NBN_MAX_DRIVERS` and initialized with 4 instances of the aforementioned `struct`. All 4 instances are equal, effectively assigning -1 to the `id` field of the `NBN_Driver` struct (which is an `int` type, so it's all good). It also assigns `NULL` to the second field, but it leaves the last field "uninitialized"; in quotes because it effectively zero initializes it. The edited version of this, which fixes the warning, is to assign to all 4 `struct`'s `{ .id = -1 }`, which only assigns -1 to the `id` field, leaving all the other fields zero initialized (in case of `char *` type, it's equivalent to assign to `NULL` or to 0).

Signed-off by: iWas-Coder <wasymatieh01@gmail.com>