### PR TITLE
Update Sunder bindings text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A little online tank game prototype.
 
 A list of user-contributed bindings (they are not officially supported, so they may be outdated):
 
-- [nbnet-sunder](https://github.com/ashn-dot-dev/nbnet-sunder) by [@ashn](https://github.com/ashn-dot-dev) ([Sunder](https://github.com/ashn-dot-dev/sunder) is a C-like systems programming language and compiler for x86-64 Linux, ARM64 Linux, and WebAssembly)
+- [nbnet-sunder](https://github.com/ashn-dot-dev/nbnet-sunder) by [@ashn](https://github.com/ashn-dot-dev) ([Sunder](https://github.com/ashn-dot-dev/sunder) is a modest systems programming language for Unix-like platforms)
 
 ## Drivers
 


### PR DESCRIPTION
[Sunder](https://github.com/ashn-dot-dev/sunder) has gotten a few upgrades since the original bindings text was written. Sunder now additionally compiles on macOS, and nbnet has been successfully used with the Sunder bindings for [Natac](https://github.com/ashn-dot-dev/natac) on both Linux and macOS. Additionally, there are plans to port Sunder to additional platforms in the future (e.g. FreeBSD).

This changeset updates the Sunder bindings text to reflect the current one-line summary for the language, as well as remove mention of any specific platforms, since more and more Unix-like platforms will naturally be added over time, and thus more and more platforms will support the Sunder bindings of nbnet.