### PR TITLE
Fix memory leak for read_chunk_buffer and write_chunk_buffer

### DIFF
--- a/nbnet.h
+++ b/nbnet.h
@@ -4092,6 +4092,9 @@ void NBN_Channel_Destroy(NBN_Channel *channel)
         }
     }
 
+    NBN_Deallocator(channel->read_chunk_buffer);
+    NBN_Deallocator(channel->write_chunk_buffer);
+
     NBN_Deallocator(channel);
 }
 


### PR DESCRIPTION
I found a memory leak using ASAN. It seems generally harmless since it would typically only leak at application shutdown.