### PR TITLE
Fix buffer overflow when handling large signalling descriptions

### DIFF
--- a/net_drivers/webrtc_c.h
+++ b/net_drivers/webrtc_c.h
@@ -40,6 +40,7 @@ freely, subject to the following restrictions:
 #include <time.h>
 #include <string.h>
 #include <rtc/rtc.h>
+#include <stdlib.h>
 #include "json.h"
 
 #define NBN_WEBRTC_C_DRIVER_ID 2
@@ -496,10 +497,12 @@ static void NBN_WebRTC_C_DestroyPeer(NBN_WebRTC_C_Peer *peer)
 
 static void NBN_WebRTC_C_ProcessLocalDescription(NBN_WebRTC_C_Peer *peer, const char *sdp, const char *type)
 {
-    char signaling_json[1024];
     char *escaped_sdp = NBN_WebRTC_C_EscapeSDP(sdp);
+    size_t signaling_json_size = snprintf(NULL, 0, "{\"type\":\"%s\", \"sdp\":\"%s\"}", type, escaped_sdp) + 1;
 
-    snprintf(signaling_json, sizeof(signaling_json), "{\"type\":\"%s\", \"sdp\":\"%s\"}", type, escaped_sdp);
+    char* signaling_json = (char *) malloc(signaling_json_size);
+
+    snprintf(signaling_json, signaling_json_size, "{\"type\":\"%s\", \"sdp\":\"%s\"}", type, escaped_sdp);
     NBN_LogDebug("Send signaling message of type %s to remote connection: %s", type, signaling_json);
 
     // pass -1 as the size (assume signaling_json to be a null-terminated string)
@@ -507,7 +510,7 @@ static void NBN_WebRTC_C_ProcessLocalDescription(NBN_WebRTC_C_Peer *peer, const 
     {
         NBN_WebRTC_C_DestroyPeer(peer);
     }
-
+    free(signaling_json);
     NBN_Deallocator(escaped_sdp);
 }
 

--- a/net_drivers/webrtc_c.h
+++ b/net_drivers/webrtc_c.h
@@ -40,7 +40,6 @@ freely, subject to the following restrictions:
 #include <time.h>
 #include <string.h>
 #include <rtc/rtc.h>
-#include <stdlib.h>
 #include "json.h"
 
 #define NBN_WEBRTC_C_DRIVER_ID 2
@@ -500,7 +499,7 @@ static void NBN_WebRTC_C_ProcessLocalDescription(NBN_WebRTC_C_Peer *peer, const 
     char *escaped_sdp = NBN_WebRTC_C_EscapeSDP(sdp);
     size_t signaling_json_size = snprintf(NULL, 0, "{\"type\":\"%s\", \"sdp\":\"%s\"}", type, escaped_sdp) + 1;
 
-    char* signaling_json = (char *) malloc(signaling_json_size);
+    char* signaling_json = (char *) NBN_Allocator(signaling_json_size);
 
     snprintf(signaling_json, signaling_json_size, "{\"type\":\"%s\", \"sdp\":\"%s\"}", type, escaped_sdp);
     NBN_LogDebug("Send signaling message of type %s to remote connection: %s", type, signaling_json);
@@ -510,7 +509,7 @@ static void NBN_WebRTC_C_ProcessLocalDescription(NBN_WebRTC_C_Peer *peer, const 
     {
         NBN_WebRTC_C_DestroyPeer(peer);
     }
-    free(signaling_json);
+    NBN_Deallocator(signaling_json);
     NBN_Deallocator(escaped_sdp);
 }
 


### PR DESCRIPTION
This can happen when a computer has lots of network interfaces, for example when running docker.

This is the signalling JSON from my PC:

```json
{"type":"answer", "sdp":"v=0\r\no=rtc 190772944 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE 0\r\na=msid-semantic:WMS *\r\na=ice-options:ice2,trickle\r\na=fingerprint:sha-256 14:C6:74:62:AF:64:75:F9:07:30:5B:F5:13:06:BD:0A:2F:E1:69:A3:2E:83:43:9E:93:57:FF:51:0E:70:D7:CD\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\nc=IN IP4 0.0.0.0\r\na=mid:0\r\na=sendrecv\r\na=sctp-port:5000\r\na=max-message-size:262144\r\na=setup:active\r\na=ice-ufrag:HRcS\r\na=ice-pwd:npVVI0DyEA2/KXM7q/u3r4\r\na=candidate:9 1 UDP 2130704383 fdbf:cd27:1133::9 60386 typ host\r\na=candidate:1 1 UDP 2122317823 X.X.X.X 60386 typ host\r\na=candidate:2 1 UDP 2122317567 X.X.X.X 60386 typ host\r\na=candidate:3 1 UDP 2122317311 172.18.0.1 60386 typ host\r\na=candidate:4 1 UDP 2122317055 172.23.0.1 60386 typ host\r\na=candidate:5 1 UDP 2122316799 172.19.0.1 60386 typ host\r\na=candidate:6 1 UDP 2122316543 172.20.0.1 60386 typ host\r\na=candidate:7 1 UDP 2122316287 172.25.0.1 60386 typ host\r\na=candidate:8 1 UDP 2122316031 172.26.0.1 60386 typ host\r\na=end-of-candidates\r\n"}
```

it did not fit in the 1024 byte buffer, so I changed it to a dynamically allocated one on the heap. This code runs only when establishing a connection, so some dynamic allocation is not that bad. 