### PR TITLE
Enable build flags and fix compilation warnings (gcc 14.1.0)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,4 +7,4 @@ add_subdirectory(echo_bytes)
 if (NOT DEFINED CPP_COMPILE)
     # not supported in CPP
     add_subdirectory(rpc)
-endif (CPP_COMPILE)
+endif (NOT DEFINED CPP_COMPILE)

--- a/examples/echo/CMakeLists.txt
+++ b/examples/echo/CMakeLists.txt
@@ -13,7 +13,7 @@ if (CPP_COMPILE)
   set (CMAKE_CXX_STANDARD 20)
 endif (CPP_COMPILE)
 
-unset(CPP_COMPILE)
+unset(CPP_COMPILE CACHE)
 
 add_executable(echo_client client.c shared.c)
 add_executable(echo_server server.c shared.c)

--- a/examples/echo/CMakeLists.txt
+++ b/examples/echo/CMakeLists.txt
@@ -15,10 +15,10 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
-add_compile_options(-Wall -Wpedantic)
+add_compile_options(-Wall)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(-Wextra)
+    add_compile_options(-Wextra -Wpedantic)
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(echo_client client.c shared.c)

--- a/examples/echo/CMakeLists.txt
+++ b/examples/echo/CMakeLists.txt
@@ -15,10 +15,10 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
+add_compile_options(-Wall -Wextra -Wpedantic)
+
 add_executable(echo_client client.c shared.c)
 add_executable(echo_server server.c shared.c)
-
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 if (ENABLE_TLS)
     message("Compile with TLS enabled")

--- a/examples/echo/CMakeLists.txt
+++ b/examples/echo/CMakeLists.txt
@@ -15,7 +15,11 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+add_compile_options(-Wall -Wpedantic)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wextra)
+endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(echo_client client.c shared.c)
 add_executable(echo_server server.c shared.c)

--- a/examples/echo/server.c
+++ b/examples/echo/server.c
@@ -125,6 +125,8 @@ int main(int argc, const char **argv)
 #endif
     }
 
+    (void) argc;
+    (void) argv;
     // Registering messages, have to be done after NBN_GameServer_StartEx
     NBN_GameServer_RegisterMessage(ECHO_MESSAGE_TYPE,
             (NBN_MessageBuilder)EchoMessage_Create,

--- a/examples/echo_bytes/CMakeLists.txt
+++ b/examples/echo_bytes/CMakeLists.txt
@@ -16,7 +16,7 @@ unset(CPP_COMPILE CACHE)
 add_compile_options(-Wall -Wpedantic)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(-Wextra)
+    add_compile_options(-Wextra -Wpedantic)
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(echo_bytes_client client.c shared.c)

--- a/examples/echo_bytes/CMakeLists.txt
+++ b/examples/echo_bytes/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CPP_COMPILE)
   set (CMAKE_CXX_STANDARD 20)
 endif (CPP_COMPILE)
 
-unset(CPP_COMPILE)
+unset(CPP_COMPILE CACHE)
 
 add_executable(echo_bytes_client client.c shared.c)
 add_executable(echo_bytes_server server.c shared.c)

--- a/examples/echo_bytes/CMakeLists.txt
+++ b/examples/echo_bytes/CMakeLists.txt
@@ -13,7 +13,7 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
-add_compile_options(-Wall -Wpedantic)
+add_compile_options(-Wall)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     add_compile_options(-Wextra -Wpedantic)

--- a/examples/echo_bytes/CMakeLists.txt
+++ b/examples/echo_bytes/CMakeLists.txt
@@ -13,7 +13,11 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+add_compile_options(-Wall -Wpedantic)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wextra)
+endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(echo_bytes_client client.c shared.c)
 add_executable(echo_bytes_server server.c shared.c)

--- a/examples/echo_bytes/CMakeLists.txt
+++ b/examples/echo_bytes/CMakeLists.txt
@@ -13,10 +13,10 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
+add_compile_options(-Wall -Wextra -Wpedantic)
+
 add_executable(echo_bytes_client client.c shared.c)
 add_executable(echo_bytes_server server.c shared.c)
-
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 target_compile_definitions(echo_bytes_client PUBLIC NBN_DEBUG)
 target_compile_definitions(echo_bytes_server PUBLIC NBN_DEBUG)

--- a/examples/raylib/CMakeLists.txt
+++ b/examples/raylib/CMakeLists.txt
@@ -7,10 +7,10 @@ set(raylib_DIR cmake)
 set(CLIENT_SOURCES client.c shared.c)
 set(SERVER_SOURCES server.c shared.c)
 
-add_compile_options(-Wall -Wpedantic -Wno-unknown-pragmas -Wno-type-limits -std=c99)
+add_compile_options(-Wall -Wno-unknown-pragmas -Wno-type-limits -std=c99)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(-Wextra)
+    add_compile_options(-Wextra -Wpedantic)
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(raylib_client ${CLIENT_SOURCES})

--- a/examples/raylib/CMakeLists.txt
+++ b/examples/raylib/CMakeLists.txt
@@ -7,7 +7,11 @@ set(raylib_DIR cmake)
 set(CLIENT_SOURCES client.c shared.c)
 set(SERVER_SOURCES server.c shared.c)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wno-type-limits -std=c99)
+add_compile_options(-Wall -Wpedantic -Wno-unknown-pragmas -Wno-type-limits -std=c99)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wextra)
+endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(raylib_client ${CLIENT_SOURCES})
 add_executable(raylib_server ${SERVER_SOURCES})

--- a/examples/rpc/CMakeLists.txt
+++ b/examples/rpc/CMakeLists.txt
@@ -13,10 +13,10 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
+add_compile_options(-Wall -Wextra -Wpedantic)
+
 add_executable(rpc_client client.c shared.c)
 add_executable(rpc_server server.c shared.c)
-
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 target_compile_definitions(rpc_client PUBLIC NBN_DEBUG)
 target_compile_definitions(rpc_server PUBLIC NBN_DEBUG)

--- a/examples/rpc/CMakeLists.txt
+++ b/examples/rpc/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CPP_COMPILE)
   set (CMAKE_CXX_STANDARD 20)
 endif (CPP_COMPILE)
 
-unset(CPP_COMPILE)
+unset(CPP_COMPILE CACHE)
 
 add_executable(rpc_client client.c shared.c)
 add_executable(rpc_server server.c shared.c)

--- a/examples/rpc/CMakeLists.txt
+++ b/examples/rpc/CMakeLists.txt
@@ -13,10 +13,10 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
-add_compile_options(-Wall -Wpedantic)
+add_compile_options(-Wall)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(-Wextra)
+    add_compile_options(-Wextra -Wpedantic)
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(rpc_client client.c shared.c)

--- a/examples/rpc/CMakeLists.txt
+++ b/examples/rpc/CMakeLists.txt
@@ -13,7 +13,11 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE CACHE)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+add_compile_options(-Wall -Wpedantic)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wextra)
+endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(rpc_client client.c shared.c)
 add_executable(rpc_server server.c shared.c)

--- a/examples/rpc/client.c
+++ b/examples/rpc/client.c
@@ -35,6 +35,8 @@ static bool disconnected = false;
 
 static void TestRPC2(unsigned int param_count, NBN_RPC_Param params[NBN_RPC_MAX_PARAM_COUNT], NBN_ConnectionHandle sender)
 {
+    (void) sender;
+    TEST_VERIFY(param_count == 2);
     Log(LOG_INFO, "TestRPC2 called !");
     Log(LOG_INFO, "Parameter 1 (float): %f", NBN_RPC_GetFloat(params, 0));
     Log(LOG_INFO, "Parameter 2 (string): %s", NBN_RPC_GetString(params, 1));
@@ -48,7 +50,7 @@ void OnConnected(void)
 
     int ret = NBN_GameClient_CallRPC(TEST_RPC_ID, 4242, -1234.5678f, true);
 
-    assert(ret == 0);
+    TEST_VERIFY(ret == 0);
 }
 
 void OnDisconnected(void)
@@ -62,6 +64,8 @@ void OnDisconnected(void)
 
 int main(int argc, char *argv[])
 {
+    (void) argc;
+    (void) argv;
 #ifdef __EMSCRIPTEN__
     NBN_WebRTC_Register(); // Register the WebRTC driver
 #else
@@ -84,11 +88,11 @@ int main(int argc, char *argv[])
 
     int ret = NBN_GameClient_RegisterRPC(TEST_RPC_ID, TEST_RPC_SIGNATURE, NULL);
 
-    assert(ret == 0);
+    TEST_VERIFY(ret == 0);
 
     ret = NBN_GameClient_RegisterRPC(TEST_RPC_2_ID, TEST_RPC_2_SIGNATURE, TestRPC2);
 
-    assert(ret == 0);
+    TEST_VERIFY(ret == 0);
 
     // Number of seconds between client ticks
     double dt = 1.0 / RPC_TICK_RATE;

--- a/examples/rpc/server.c
+++ b/examples/rpc/server.c
@@ -29,12 +29,11 @@
 
 #include "shared.h"
 
-static NBN_Connection *client = NULL;
-
 static bool error = false;
 
 static void TestRPC(unsigned int param_count, NBN_RPC_Param params[NBN_RPC_MAX_PARAM_COUNT], NBN_ConnectionHandle sender)
 {
+    TEST_VERIFY(param_count == 3);
     Log(LOG_INFO, "TestRPC called ! (Sender: %d)", sender);
     Log(LOG_INFO, "Parameter 1 (int): %d", NBN_RPC_GetInt(params, 0));
     Log(LOG_INFO, "Parameter 2 (float): %f", NBN_RPC_GetFloat(params, 1));

--- a/examples/rpc/shared.h
+++ b/examples/rpc/shared.h
@@ -23,6 +23,8 @@
 #ifndef RPC_EXAMPLE_SHARED_H
 #define RPC_EXAMPLE_SHARED_H
 
+#include <stdlib.h>
+
 #if defined(_WIN32) || defined(_WIN64)
 
 /*
@@ -86,6 +88,7 @@ typedef struct tagMSG *LPMSG;
 #define TEST_RPC_2_ID 1
 #define TEST_RPC_SIGNATURE NBN_RPC_BuildSignature(3, NBN_RPC_PARAM_INT, NBN_RPC_PARAM_FLOAT, NBN_RPC_PARAM_BOOL)
 #define TEST_RPC_2_SIGNATURE NBN_RPC_BuildSignature(2, NBN_RPC_PARAM_FLOAT, NBN_RPC_PARAM_STRING)
+#define TEST_VERIFY(exp)  if(!(exp)) abort()
 
 // nbnet logging
 // nbnet does not implement any logging capabilities, you need to provide your own

--- a/nbnet.h
+++ b/nbnet.h
@@ -2215,7 +2215,7 @@ int NBN_ReadStream_SerializeBool(NBN_ReadStream *read_stream, bool *value)
     if (NBN_BitReader_Read(&read_stream->bit_reader, &v, 1) < 0)
         return NBN_ERROR;
 
-    if (v < 0 || v > 1)
+    if (v > 1)
         return NBN_ERROR;
 
     *value = v;
@@ -3574,7 +3574,7 @@ static NBN_RPC_Message *Connection_BuildRPC(NBN_Connection *connection, NBN_RPC 
 
 static void Connection_HandleReceivedRPC(NBN_ConnectionHandle connection, NBN_Endpoint *endpoint, NBN_RPC_Message *msg)
 {
-    if (msg->id < 0 || msg->id > NBN_RPC_MAX - 1)
+    if (msg->id > NBN_RPC_MAX - 1)
     {
         NBN_LogError("Received an invalid RPC");
 
@@ -4271,7 +4271,7 @@ static NBN_Connection *Endpoint_CreateConnection(NBN_Endpoint *endpoint, uint32_
 
 static int Endpoint_RegisterRPC(NBN_Endpoint *endpoint, unsigned int id, NBN_RPC_Signature signature, NBN_RPC_Func func)
 {
-    if (id < 0 || id >= NBN_RPC_MAX)
+    if (id >= NBN_RPC_MAX)
     {
         NBN_LogError("Failed to register RPC, invalid ID");
 
@@ -4881,7 +4881,7 @@ int NBN_GameClient_CallRPC(unsigned int id, ...)
 {
     NBN_RPC rpc = nbn_game_client.endpoint.rpcs[id];
 
-    if (rpc.id < 0 || rpc.id != id)
+    if (rpc.id != id)
     {
         NBN_LogError("Cannot call invalid RPC (ID: %d)", id);
 
@@ -5430,7 +5430,7 @@ int NBN_GameServer_CallRPC(unsigned int id, NBN_ConnectionHandle connection_hand
 
     NBN_RPC rpc = nbn_game_server.endpoint.rpcs[id];
 
-    if (rpc.id < 0 || rpc.id != id)
+    if (rpc.id != id)
     {
         NBN_LogError("Cannot call invalid RPC (ID: %d)", id);
 

--- a/nbnet.h
+++ b/nbnet.h
@@ -2258,7 +2258,7 @@ int NBN_ReadStream_SerializeBytes(NBN_ReadStream *read_stream, uint8_t *bytes, u
     // make sure we are at the start of a new byte after applying padding
     assert(bit_reader->scratch_bits_count % 8 == 0);
 
-    if (length * 8 <= bit_reader->scratch_bits_count)
+    if (length * 8 <= bit_reader->scratch_bits_count && length <= sizeof(Word))
     {
         // the byte array is fully contained inside the read word
 

--- a/nbnet.h
+++ b/nbnet.h
@@ -5588,7 +5588,7 @@ static void GameServer_AddClientToClosedList(NBN_Connection *client)
     }
 }
 
-static unsigned int GameServer_GetClientCount(void)
+static inline unsigned int GameServer_GetClientCount(void)
 {
     return nbn_game_server.clients->count;
 }

--- a/nbnet.h
+++ b/nbnet.h
@@ -154,7 +154,7 @@ typedef uint32_t Word;
 #define B_IS_SET(mask, n) ((B_MASK(n) & mask) == B_MASK(n))
 #define B_IS_UNSET(mask, n) ((B_MASK(n) & mask) == 0)
 
-#define ASSERT_VALUE_IN_RANGE(v, min, max) assert(v >= min && v <= max)
+#define ASSERT_VALUE_IN_RANGE(v, min, max) assert(v >= (int64_t)min && v <= (int64_t)max)
 #define ASSERTED_SERIALIZE(stream, v, min, max, func)       \
 {                                                           \
     if (stream->type == NBN_STREAM_WRITE)                   \

--- a/nbnet.h
+++ b/nbnet.h
@@ -2636,6 +2636,8 @@ int NBN_Packet_WriteMessage(NBN_Packet *packet, NBN_Message *message, NBN_Messag
 
 int NBN_Packet_Seal(NBN_Packet *packet, NBN_Connection *connection)
 {
+    (void) connection;
+
     if (packet->mode != NBN_PACKET_MODE_WRITE)
         return NBN_ERROR;
 
@@ -3027,6 +3029,7 @@ int NBN_Connection_EnqueueOutgoingMessage(NBN_Connection *connection, NBN_Channe
 {
     assert(!connection->is_closed || message->header.type == NBN_CLIENT_CLOSED_MESSAGE_TYPE);
     assert(!connection->is_stale);
+    (void) connection;
 
     NBN_LogTrace("Enqueue message of type %d on channel %d", message->header.type, channel->id);
 
@@ -3183,6 +3186,8 @@ int NBN_Connection_InitChannel(NBN_Connection *connection, NBN_Channel *channel)
 bool NBN_Connection_CheckIfStale(NBN_Connection *connection, double time)
 {
 #if defined(NBN_DEBUG) && defined(NBN_DISABLE_STALE_CONNECTION_DETECTION)
+    (void) connection;
+    (void) time;
     /* When testing under bad network conditions (in soak test for instance), we don't want to deal
        with stale connections */
     return false;

--- a/nbnet.h
+++ b/nbnet.h
@@ -1531,18 +1531,6 @@ struct NBN_Driver
     NBN_DriverImplementation impl;
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-static NBN_Driver nbn_drivers[NBN_MAX_DRIVERS] = {
-    {-1, NULL},
-    {-1, NULL},
-    {-1, NULL},
-    {-1, NULL}
-};
-#pragma clang diagnostic pop
-
-static unsigned int nbn_driver_count = 0;
-
 /**
  * Register a new network driver, at least one network driver has to be registered.
  *
@@ -1592,6 +1580,15 @@ int NBN_Driver_RaiseEvent(NBN_DriverEvent ev, void *data);
 #pragma region Implementations
 
 #ifdef NBNET_IMPL
+
+static NBN_Driver nbn_drivers[NBN_MAX_DRIVERS] = {
+    {.id = -1},
+    {.id = -1},
+    {.id = -1},
+    {.id = -1}
+};
+
+static unsigned int nbn_driver_count = 0;
 
 #pragma region NBN_ConnectionVector
 

--- a/soak/CMakeLists.txt
+++ b/soak/CMakeLists.txt
@@ -12,10 +12,10 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE)
 
+add_compile_options(-Wall -Wextra -Wpedantic)
+
 add_executable(client client.c soak.c logging.c cargs.c)
 add_executable(server server.c soak.c logging.c cargs.c)
-
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 target_compile_definitions(client PUBLIC NBN_DEBUG NBN_DISABLE_STALE_CONNECTION_DETECTION NBN_USE_PACKET_SIMULATOR SOAK_CLIENT)
 target_compile_definitions(server PUBLIC NBN_DEBUG NBN_DISABLE_STALE_CONNECTION_DETECTION NBN_USE_PACKET_SIMULATOR SOAK_SERVER)

--- a/soak/CMakeLists.txt
+++ b/soak/CMakeLists.txt
@@ -12,7 +12,11 @@ endif (CPP_COMPILE)
 
 unset(CPP_COMPILE)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+add_compile_options(-Wall)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wextra -Wpedantic)
+endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_executable(client client.c soak.c logging.c cargs.c)
 add_executable(server server.c soak.c logging.c cargs.c)

--- a/soak/client.c
+++ b/soak/client.c
@@ -62,7 +62,7 @@ static unsigned int done_channel_count = 0;
 
 static void GenerateRandomBytes(uint8_t *data, unsigned int length)
 {
-    for (int i = 0; i < length; i++)
+    for (unsigned int i = 0; i < length; i++)
         data[i] = rand() % 255 + 1;
 }
 
@@ -95,7 +95,7 @@ static int SendSoakMessages(SoakChannel *channel, uint8_t channel_id)
 
         Soak_LogInfo("Will send %d soak messages this tick", send_message_count);
 
-        for (int i = 0; i < send_message_count; i++)
+        for (unsigned int i = 0; i < send_message_count; i++)
         {
             SoakMessage *msg = SoakMessage_CreateOutgoing();
 
@@ -338,7 +338,7 @@ int main(int argc, char *argv[])
     unsigned int leftover_message_count = message_count % channel_count;
     SoakChannel *channels = (SoakChannel *)malloc(sizeof(SoakChannel) * channel_count);
 
-    for (int c = 0; c < channel_count; c++)
+    for (unsigned int c = 0; c < channel_count; c++)
     {
         SoakChannel *channel = &channels[c];
         

--- a/soak/client.c
+++ b/soak/client.c
@@ -356,7 +356,10 @@ int main(int argc, char *argv[])
 
     channels[channel_count - 1].message_count += leftover_message_count;
 
-    NBN_GameClient_Debug_RegisterCallback(NBN_DEBUG_CB_MSG_ADDED_TO_RECV_QUEUE, (void *)Soak_Debug_PrintAddedToRecvQueue); 
+    NBN_ConnectionDebugCallback cbs = {
+        .OnMessageAddedToRecvQueue = Soak_Debug_PrintAddedToRecvQueue,
+    };
+    NBN_GameClient_Debug_RegisterCallback(cbs);
 
     int ret = Soak_MainLoop(Tick, channels);
 

--- a/soak/server.c
+++ b/soak/server.c
@@ -375,7 +375,10 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    NBN_GameServer_Debug_RegisterCallback(NBN_DEBUG_CB_MSG_ADDED_TO_RECV_QUEUE, (void *)Soak_Debug_PrintAddedToRecvQueue);
+    NBN_ConnectionDebugCallback cbs = {
+        .OnMessageAddedToRecvQueue = Soak_Debug_PrintAddedToRecvQueue,
+    };
+    NBN_GameServer_Debug_RegisterCallback(cbs);
 
     int ret = Soak_MainLoop(Tick, NULL);
 

--- a/soak/server.c
+++ b/soak/server.c
@@ -309,6 +309,7 @@ static void SigintHandler(int dummy)
     unsigned int destroyed_outgoing_message_count = Soak_GetDestroyedOutgoingSoakMessageCount();
     unsigned int created_incoming_message_count = Soak_GetCreatedIncomingSoakMessageCount();
     unsigned int destroyed_incoming_message_count = Soak_GetDestroyedIncomingSoakMessageCount();
+    (void) dummy;
 
     Soak_LogInfo("Outgoing soak messages created: %d", created_outgoing_message_count);
     Soak_LogInfo("Outgoing soak messages destroyed: %d", destroyed_outgoing_message_count);

--- a/soak/soak.c
+++ b/soak/soak.c
@@ -64,6 +64,9 @@ static void Usage(void)
 
 int Soak_Init(int argc, char *argv[])
 {
+    (void) argc;
+    (void) argv;
+
     srand(SOAK_SEED);
 
     SoakOptions options = Soak_GetOptions();
@@ -258,6 +261,8 @@ SoakOptions Soak_GetOptions(void)
 
 void Soak_Debug_PrintAddedToRecvQueue(NBN_Connection *conn, NBN_Message *msg)
 {
+    (void) conn;
+    (void) msg;
     // FIXME
     /*if (msg->header.type == NBN_MESSAGE_CHUNK_TYPE)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.0)
 project(unit_tests C)
 enable_testing()
 
-add_compile_options(-Wall -Wno-unknown-pragmas)
+add_compile_options(-Wall)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(-Wextra -Wpedantic -Werror )
+    add_compile_options(-Wextra -Wpedantic -Werror -Wno-unknown-pragmas)
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 # add_executable(message_chunks message_chunks.c CuTest.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,11 +3,12 @@ cmake_minimum_required(VERSION 3.0)
 project(unit_tests C)
 enable_testing()
 
+add_compile_options(-Wall -Wextra -Werror)
+
 # add_executable(message_chunks message_chunks.c CuTest.c)
 add_executable(string_tests string_tests.c CuTest.c)
 add_executable(serialization_tests serialization.c CuTest.c)
 
-add_compile_options(-Wall -Wextra -Werror)
 target_link_libraries(string_tests -lm)
 target_link_libraries(serialization_tests -lm)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,11 @@ cmake_minimum_required(VERSION 3.0)
 project(unit_tests C)
 enable_testing()
 
-add_compile_options(-Wall -Wextra -Werror -Wno-unknown-pragmas)
+add_compile_options(-Wall -Werror -Wno-unknown-pragmas)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wextra -Wpedantic)
+endif (CMAKE_COMPILER_IS_GNUCXX)
 
 # add_executable(message_chunks message_chunks.c CuTest.c)
 add_executable(string_tests string_tests.c CuTest.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.0)
 project(unit_tests C)
 enable_testing()
 
-add_compile_options(-Wall -Werror -Wno-unknown-pragmas)
+add_compile_options(-Wall -Wno-unknown-pragmas)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(-Wextra -Wpedantic)
+    add_compile_options(-Wextra -Wpedantic -Werror )
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 # add_executable(message_chunks message_chunks.c CuTest.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 project(unit_tests C)
 enable_testing()
 
-add_compile_options(-Wall -Wextra -Werror)
+add_compile_options(-Wall -Wextra -Werror -Wno-unknown-pragmas)
 
 # add_executable(message_chunks message_chunks.c CuTest.c)
 add_executable(string_tests string_tests.c CuTest.c)

--- a/tests/serialization.c
+++ b/tests/serialization.c
@@ -102,6 +102,9 @@ void Test_SerializeUInt64(CuTest *tc)
 
 int main(int argc, char *argv[])
 {
+    (void) argc;
+    (void) argv;
+
     CuString *output = CuStringNew();
     CuSuite* suite = CuSuiteNew();
 

--- a/tests/string_tests.c
+++ b/tests/string_tests.c
@@ -47,6 +47,9 @@ int main(int argc, char *argv[])
     CuString *output = CuStringNew();
     CuSuite* suite = CuSuiteNew();
 
+    (void) argc;
+    (void) argv;
+
     SUITE_ADD_TEST(suite, Test_StringReplaceAll);
 
     CuSuiteRun(suite);

--- a/tests/string_tests.c
+++ b/tests/string_tests.c
@@ -14,14 +14,14 @@ static void StringReplaceAll(char *res, const char *str, const char *a, const ch
     {
         int pos = substr - str;
 
-        strncpy(res, str, pos);
-        strncpy(res + pos, b, len_b);
+        memcpy(res, str, pos);
+        memcpy(res + pos, b, len_b);
 
         StringReplaceAll(res + pos + len_b, str + pos + len_a, a, b);
     }
     else
     {
-        strncpy(res, str, strlen(str) + 1);
+        memcpy(res, str, strlen(str) + 1);
     }
 }
 


### PR DESCRIPTION
Current `add_compile_options()` in tests and examples are not taken into account, due to that any warnings are simply ignored. 
This patch series moves add `add_compile_options()` before target creation to resolve this issue.

Also, I tried to group warnings fixes into categories as separate patches, so it should be possible to rearrange/replace part of them.