### PR TITLE
fix possible bug in nbnet.h related to NBN_GameServer_RejectIncomingC…

### DIFF
--- a/nbnet.h
+++ b/nbnet.h
@@ -5483,7 +5483,7 @@ static int GameServer_SendMessageTo(NBN_Connection *client, uint8_t msg_type, ui
     }
 
     /* The only message type we can send to an unaccepted client is a NBN_ClientAcceptedMessage message */
-    assert(client->is_accepted || outgoing_msg->type == NBN_CLIENT_ACCEPTED_MESSAGE_TYPE);
+    assert(client->is_accepted || outgoing_msg->type == NBN_CLIENT_ACCEPTED_MESSAGE_TYPE || outgoing_msg->type == NBN_CLIENT_CLOSED_MESSAGE_TYPE);
 
     if (Endpoint_EnqueueOutgoingMessage(&nbn_game_server.endpoint, client, outgoing_msg, channel_id) < 0)
     {


### PR DESCRIPTION
…onnection

reproducing the possible bug:
- cd examples/echo
- cmake . && make
- ./echo_server (terminal 1) and ./echo_client TEST (terminal 2) and ./echo_client TEST (terminal 3)

error message related to possible bug:
```
Assertion failed: (client->is_accepted || outgoing_msg->type == NBN_CLIENT_ACCEPTED_MESSAGE_TYPE), function GameServer_SendMessageTo, file nbnet.h, line 5498
```

suggested fix if this is indeed a bug:
- add `|| outgoing_msg->type == NBN_CLIENT_CLOSED_MESSAGE_TYPE` to assertion