### PR TITLE
examples/raylib: fix build in Ubuntu Linux 24 (GCC 13.3.0)

### DIFF
--- a/examples/raylib/CMakeLists.txt
+++ b/examples/raylib/CMakeLists.txt
@@ -35,6 +35,9 @@ target_compile_definitions(raylib_client PUBLIC NBN_DEBUG)
 target_compile_definitions(raylib_server PUBLIC NBN_DEBUG)
 target_compile_definitions(raylib_server PUBLIC NBN_RAYLIB_SERVER)
 
+target_compile_definitions(raylib_client PUBLIC _GNU_SOURCE)
+target_compile_definitions(raylib_server PUBLIC _GNU_SOURCE)
+
 # compile with C WebRTC driver
 if (WEBRTC_C_DRIVER)
   # can't compile WebRTC native driver with emscripten

--- a/examples/raylib/server.c
+++ b/examples/raylib/server.c
@@ -289,6 +289,7 @@ static int BroadcastGameState(void)
 static bool running = true;
 
 #ifndef __EMSCRIPTEN__
+#include <signal.h>
 
 static void SigintHandler(int dummy)
 {


### PR DESCRIPTION
gcc 13.3.0 spits out errors regaring timespec:

```
nbnet/examples/raylib/server.c:404:16: error: variable ‘t’ has initializer but incomplete type
  404 |         struct timespec t = {.tv_sec = nanos / 999999999, .tv_nsec = nanos % 999999999};
      |                ^~~~~~~~
```

c99 includes time.h but timespec is not added automatically

changing the C standar from c99 to gnu99 fix this issue