### PR TITLE
fix compilation for FreeBSD

### DIFF
--- a/nbnet.h
+++ b/nbnet.h
@@ -49,6 +49,10 @@
 #include <sys/time.h>
 #include <time.h>
 
+#ifndef CLOCK_MONOTONIC_RAW
+#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
+#endif
+
 #endif
 
 #ifndef NBN_Allocator


### PR DESCRIPTION
freebsd's c library doesn't define CLOCK_MONOTONIC_RAW since it exists only in linux space and not in posix space. this commits adds link for it, replacing raw variant with standard one if first is not found.