### PR TITLE
  Fix segfault when disconnecting client with queued messages

### DIFF
--- a/nbnet.c
+++ b/nbnet.c
@@ -2963,7 +2963,8 @@ static bool Server_HandleMessageReceivedEvent(NBN_Server *server, NBN_Server_Eve
         last_event->type = NBN_SERVER_DISCONNECTION;
         last_event->data.disconnection = (NBN_DisconnectionInfo){sender->handle.id, sender->handle.user_data};
 
-        Server_RemoveClosedClientConnections(server);
+        // don't remove the connection yet, is_stale will take care of it later
+        // to prevent a use after free if client has outgoing messages sent after disconnect
 
         *ev = NBN_SERVER_DISCONNECTION;
         return true;


### PR DESCRIPTION
 Fixes a *potential* (not sure if it's just me using nbnet wrongly)  use after free in `Server_HandleMessageReceivedEvent` when a client disconnects while other messages from that client are still queued.

This is due to the server immediately freeing/removing connections after disconnect. If the client has any queued messages left, they will use this now freed connection in the same tick / poll.

This is fixed by removing the premature freeing in the handler, as clients will still be deleted in the next tick since the connection is marked as stale (not sure if there is a cleaner way to do this / if this is intended behavior and my project's usage of nbnet is wrong). The queued messages are also ignored due to the client being marked as stale.