### PR TITLE
[Examples/raylib] added argc alternative for wasm/emscripten

### DIFF
--- a/examples/raylib/client.c
+++ b/examples/raylib/client.c
@@ -463,24 +463,59 @@ void UpdateAndDraw(NBN_Client *client) {
     Draw(client);
 }
 
-int main(int argc, char *argv[]) {
-    // Read command line arguments expect when we are running in a web browser.
-    // When running in web browser we need another way to provide arguments (TODO)
-#ifdef __EMSCRIPTEN__
-    if (ReadCommandLine(argc, argv) < 0) {
-        printf("Usage: client [--packet_loss=<value>] [--packet_duplication=<value>] [--ping=<value>] \
-[--jitter=<value>]\n");
+// Returns a string from the URL, or a default
+// value if it's not set
+EM_JS(char*, get_query_param_string, (const char* key, const char* defaultValue), {
+    const params = new URLSearchParams(window.location.search);
 
-        return 1;
+    const value = params.get(UTF8ToString(key));
+
+    if (value === null) {
+        const defaultStr = UTF8ToString(defaultValue);
+        const len = lengthBytesUTF8(defaultStr) + 1;
+        const ptr = _malloc(len);
+
+        stringToUTF8(defaultStr, ptr, len);
+        return ptr;
     }
-#endif
 
+    const len = lengthBytesUTF8(value) + 1;
+    const ptr = _malloc(len);
+
+    stringToUTF8(value, ptr, len);
+
+    return ptr;
+});
+
+// Returns an integer value from the URL, or a default
+// value if it's not set (example only, not used here)
+// EM_JS(int, get_query_param_int, (const char* key, const int defaultValue), {
+//     const params = new URLSearchParams(window.location.search);
+//     const value = params.get(UTF8ToString(key));
+
+//     if (value === null) {
+//         return defaultValue;
+//     }
+
+//     const parsed = parseInt(value, 10);
+//     if (Number.isNaN(parsed)) {
+//         return defaultValue;
+//     }
+
+//     return parsed;
+// });
+
+int main(int argc, char *argv[]) {
+#ifdef __EMSCRIPTEN__
+    const char *name = get_query_param_string("name", "client");
+#else
     if (argc < 2) {
         printf("Usage: raylib_client NAME\n");
         return 1;
     }
 
     const char *name = argv[1];
+#endif
 
     memcpy(local_client_state.name, name, sizeof(local_client_state.name));
 


### PR DESCRIPTION
There was a TODO about how to do an argc thing and I think this is a good way to approach it. The default value is so that if nothing is supplied you can still have something

example:
`127.0.0.1/game.html` becomes `127.0.0.1/game.html?name=test123&something=42`